### PR TITLE
SRE-2900 Make binary available via GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ qrc_*
 # Build results
 [Dd]ebug*/
 [Rr]elease/
-bin/
 *.class
 build/
 .gradle/


### PR DESCRIPTION
https://jobready.atlassian.net/browse/SRE-2900

Commits the zipped binary so we can pull from GitHub rather than the "official" BitBucket store